### PR TITLE
Switch labels must be evaluable at compile time

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -121,12 +121,12 @@ void center_in_room(struct Point* player)
 	player->y = -room_height / 2;
 }
 
-const int KEY_D = 100;
-const int KEY_W = 119;
-const int KEY_A = 97;
-const int KEY_S = 115;
-const int KEY_M = 109;
-const int KEY_ENTER = 10;
+#define KEY_D 100
+#define KEY_W 119
+#define KEY_A 97
+#define KEY_S 115
+#define KEY_M 109
+#define KEY_ENTER 10
 
 struct Point move_in_direction(
 	struct Point old_pos, enum Direction direction)
@@ -183,28 +183,28 @@ int collision_detection(
 
 void position_move(char ch, struct Point* pos) {
 	switch(ch) {
-		case KEY_W: 
+		case KEY_W:
 			mvprintw(5, 10, "KEY_UP!");
 			if(collision_detection(*pos, UP))
 				break;
 
 			pos->y--;
 			break;
-		case KEY_S: 
+		case KEY_S:
 			mvprintw(5, 10, "KEY_DOWN!");
 			if(collision_detection(*pos, DOWN))
 				break;
 
 			pos->y++;
 			break;
-		case KEY_A: 
+		case KEY_A:
 			mvprintw(5, 10, "KEY_LEFT!");
 			if(collision_detection(*pos, LEFT))
 				break;
 
 			pos->x--;
 			break;
-		case KEY_D: 
+		case KEY_D:
 			mvprintw(5, 10, "KEY_RIGHT!");
 			if(collision_detection(*pos, RIGHT))
 				break;
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
 
 	char* starting_rules = "se";
 	if(argc > 2) {
-		starting_rules = argv[2];	
+		starting_rules = argv[2];
 	}
 
 	int num_replacements = 10;
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
 		mvprintw(1, 10,
 				"Dungeon (total number of frames printed %d)", tmp);
 		mvprintw(3, 10, "Debug rule:");
-		
+
 		mvprintw(5, 40, "id replace\n");
 		for(int i=0; i < rw.number_of_rules; i++) {
 			mvprintw(6+i, 40, "%c  %s\n",
@@ -282,7 +282,7 @@ int main(int argc, char **argv)
 				starting_rules,
 				num_replacements,
 				rw.number_of_rules
-			); 
+			);
 
 			// Travel the dungeon rule and gennerates a DAG
 			dag = create_dag_from_dungeonrule(output);
@@ -332,7 +332,7 @@ int main(int argc, char **argv)
 				show_map = show_map==1 ? 0 : 1;
 		}
 	}
-	
+
 	free(output);
 	free(dag);
 


### PR DESCRIPTION
It's maybe the case for C++, but in pure C `const int` is generally not evaluable at compile time. That's why everybody `#define`s their constants.

Without the change I have a compilation error:

```
make -k 
gcc -ggdb -g src/main.c -lncurses -Ibuild -o ./build/main
src/main.c: In function ‘position_move’:
src/main.c:186:3: error: case label does not reduce to an integer constant
   case KEY_W:
   ^~~~
src/main.c:193:3: error: case label does not reduce to an integer constant
   case KEY_S:
   ^~~~
src/main.c:200:3: error: case label does not reduce to an integer constant
   case KEY_A:
   ^~~~
src/main.c:207:3: error: case label does not reduce to an integer constant
   case KEY_D:
   ^~~~
src/main.c: In function ‘main’:
src/main.c:331:4: error: case label does not reduce to an integer constant
    case KEY_M:
    ^~~~
make: *** [Makefile:5: src/main] Error 1
make: Target 'all' not remade because of errors.
```